### PR TITLE
Improve parsing of two-digit years.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -15,6 +15,26 @@ I've forked it out of [WONDER](http://sourceforge.net/projects/wonder/), "an umb
         </dependency>
     </dependencies>
 
+## Parsing of two-digit years ##
+
+The parsing of two-digit years can be controlled with one of the `Pointer.PointerType` values `NONE`, `PAST` or
+`FUTURE` like this:
+
+```
+Options opts = new Options(Pointer.PointerType.PAST);
+Span result = Chronic.parse("1/2/38", options);   // Year is treated as 1938 because of PointerType.PAST.
+```
+
+The behavior is like this:
+
+| `PointerType` | 1-19 | 20-37 | 38-68 | 69-99 | 100-137 |
+|---------------|------|-------|-------|-------|---------|
+| `NONE`        | 20xx | 20xx  | error | 19xx  | 20xx    |
+| `PAST`        | 20xx | 19xx  | 19xx  | 19xx  | 20xx    |
+| `FUTURE`      | 20xx | 20xx  | 20xx  | 19xx  | 20xx    |
+
+Earlier versions of this library ignored the given options and always behaved like the `NONE` line in the table.
+
 ## Credits ##
 This was originally written by Mike Schrag as part of the WONDER project.
 

--- a/src/main/java/com/mdimension/jchronic/tags/ScalarYear.java
+++ b/src/main/java/com/mdimension/jchronic/tags/ScalarYear.java
@@ -21,11 +21,48 @@ public class ScalarYear extends Scalar {
     if (ScalarYear.YEAR_PATTERN.matcher(token.getWord()).matches()) {
       int scalarValue = Integer.parseInt(token.getWord());
       if (!(postToken != null && Scalar.TIMES.contains(postToken.getWord()))) {
-        if (scalarValue <= 37) {
-          scalarValue += 2000;
-        }
-        else if (scalarValue <= 137 && scalarValue >= 69) {
-          scalarValue += 1900;
+        Pointer.PointerType context = options.getContext();
+        switch (context) {
+          case NONE:
+            // If the context indicates no bias,
+            // treat anything up to 37 as 20xx, anything from 69-99 as 19xx,
+            // anything from 100-137 as 20xx, and leave 38-68 alone (treating
+            // that range as ambiguous, I guess).
+            // This used to be the behavior regardless of the context.
+            if (scalarValue <= 37) {
+              scalarValue += 2000;
+            }
+            else if (scalarValue <= 137 && scalarValue >= 69) {
+              scalarValue += 1900;
+            }
+            break;
+
+          case PAST:
+            // If the context indicates a bias to past dates,
+            // treat anything from 20-99 as 19xx, and otherwise
+            // match the NONE behavior.
+            if (scalarValue <= 19) {
+              scalarValue += 2000;
+            }
+            else if (scalarValue <= 99) {
+              scalarValue += 1900;
+            }
+            else if (scalarValue <= 137) {
+              scalarValue += 1900;
+            }
+            break;
+
+          case FUTURE:
+            // If the context indicates a bias to future dates,
+            // treat anything up to 68 as 20xx, and otherwise
+            // match the NONE behavior.
+            if (scalarValue <= 68) {
+              scalarValue += 2000;
+            }
+            else if (scalarValue <= 137) {
+              scalarValue += 1900;
+            }
+            break;
         }
         return new ScalarYear(Integer.valueOf(scalarValue));
       }

--- a/src/test/java/com/mdimension/jchronic/ParserTest.java
+++ b/src/test/java/com/mdimension/jchronic/ParserTest.java
@@ -120,7 +120,8 @@ public class ParserTest extends TestCase {
     time = parse_now("27/5/1979 @ 0700");
     assertEquals(Time.construct(1979, 5, 27, 7), time);
 
-    // sm_sy
+    // sm_sy with FUTURE pointer (the default).
+    // Year 06 == 2006; year 19 == 2019; year 20 == 2020; year 40 == 2040; year 99 == 1999.
 
     time = parse_now("05/06");
     assertEquals(Time.construct(2006, 5, 16, 12), time);
@@ -130,6 +131,56 @@ public class ParserTest extends TestCase {
 
     time = parse_now("13/06");
     assertEquals(null, time);
+
+    time = parse_now("12/19");
+    assertEquals(Time.construct(2019, 12, 16, 12), time);
+
+    time = parse_now("12/20");
+    assertEquals(Time.construct(2020, 12, 16, 12), time);
+
+    time = parse_now("12/40");
+    assertEquals(Time.construct(2040, 12, 16, 12), time);
+
+    time = parse_now("12/99");
+    assertEquals(Time.construct(1999, 12, 16, 12), time);
+
+    // sm_sy with NONE pointer
+    // Year 06 == 2006; year 19 == 2019; year 20 == 2020; year 40 == error; year 99 == 1999.
+
+    Options optionsPointerNone = new Options(Pointer.PointerType.NONE);
+    time = parse_now("12/06", optionsPointerNone);
+    assertEquals(Time.construct(2006, 12, 16, 12), time);
+
+    time = parse_now("12/19", optionsPointerNone);
+    assertEquals(Time.construct(2019, 12, 16, 12), time);
+
+    time = parse_now("12/20", optionsPointerNone);
+    assertEquals(Time.construct(2020, 12, 16, 12), time);
+
+    time = parse_now("12/40", optionsPointerNone);
+    assertEquals(null, time);
+
+    time = parse_now("12/99", optionsPointerNone);
+    assertEquals(Time.construct(1999, 12, 16, 12), time);
+
+    // sm_sy with PAST pointer
+    // Year 06 == 2006; year 19 == 2019; year 20 == 1920; year 40 == 1940; year 99 == 1999.
+
+    Options optionsPointerPast = new Options(Pointer.PointerType.PAST);
+    time = parse_now("12/06", optionsPointerPast);
+    assertEquals(Time.construct(2006, 12, 16, 12), time);
+
+    time = parse_now("12/19", optionsPointerPast);
+    assertEquals(Time.construct(2019, 12, 16, 12), time);
+
+    time = parse_now("12/20", optionsPointerPast);
+    assertEquals(Time.construct(1920, 12, 16, 12), time);
+
+    time = parse_now("12/40", optionsPointerPast);
+    assertEquals(Time.construct(1940, 12, 16, 12), time);
+
+    time = parse_now("12/99", optionsPointerPast);
+    assertEquals(Time.construct(1999, 12, 16, 12), time);
 
     // sy_sm_sd
 
@@ -170,10 +221,10 @@ public class ParserTest extends TestCase {
 
     // due to limitations of the Time class, these don't work
 
-    time = parse_now("may 40");
+    time = parse_now("may 40", optionsPointerNone);
     assertEquals(null, time);
 
-    time = parse_now("may 27 40");
+    time = parse_now("may 27 40", optionsPointerNone);
     assertEquals(null, time);
 
     time = parse_now("1800-08-20");


### PR DESCRIPTION
This extends the behavior of ScalarYear when handling two digit years
(and indeed any year in the range 1-137).  Previously, the code treated
years in the range 38-68 as errors, 69-99 as 19xx, and the rest as 20xx.
This change uses the PointerType value in the options to change the
behavior.  If PointerType.PAST is passed, 20-68 is treated as
19xx (so you can parse birth dates for old people, for example).  If
PointerType.FUTURE is passed then 1-68 is treated as 20xx.
Using PointerType.NONE treats 38-68 as an error, as before.

Note that this is a change of behavior, because Options defaults to
use PointerType.FUTURE.  To get the old behavior back, you will need to
set PointerType.NONE explicitly.